### PR TITLE
docs: add disabling of logs for independent usage of language server with neovim

### DIFF
--- a/language-server/README.md
+++ b/language-server/README.md
@@ -9,6 +9,11 @@ npm install
 npm package
 ```
 
+If you want to use this with Neovim (that is when using the `--stdio` option) you need to disable all console logging by running this before `npm run package`:
+```sh
+find src/ -name '*.ts' | xargs sed -i -e 's,console\.,{} // console.,'
+```
+
 This should create a file called `openplanet-angelscript-ls-1.0.0.tgz` which can be installed by running:
 
 ```sh


### PR DESCRIPTION
Add a note for disabling of console logs when installing the language server independently for neovim (or with when using `--stdio` in general) 